### PR TITLE
Update nzbto.py

### DIFF
--- a/sickbeard/providers/nzbto.py
+++ b/sickbeard/providers/nzbto.py
@@ -101,15 +101,30 @@ class NzbtoProvider(generic.NZBProvider):
 
             x = self.session.get(tmp_url)
             pw = False
+            p00_test3 = "Test"
             with BS4Parser(x.text, "html.parser") as html:
                 pw = html.find('span', attrs={"style": "color:#ff0000"})
                 if pw:
-                    pw = pw.strong.next.next
-
+                    pw = pw.strong
+                    #logger.log('Password Check: {{%s}}' %(pw.strip()), logger.DEBUG)
+                    pw = pw.next
+                    #logger.log('Password Check0: {{%s}}' %(pw.strip()), logger.DEBUG)
+                    pw = pw.next
+                    #logger.log('Password Check1: {{%s}}' %(pw.strip()), logger.DEBUG)
+                    p00_test = unicode(pw.string)
+                    #ogger.log('Password Check2: {{%s}}' %(p00_test), logger.DEBUG)
+                    p00_test2 = p00_test.decode(encoding='ascii',errors='ignore')
+                    #logger.log('Password Check3: {{%s}}' %(p00_test2), logger.DEBUG)
+                    p00_test3 = strip_non_ascii(p00_test2)
+                    #logger.log('Password Check4: {{%s}}' %(p00_test3), logger.DEBUG)
+					
             if not pw or pw.strip() == "-":
                 title = tmp_title
             else:
-                title = "%s{{%s}}" % (tmp_title, pw.strip())
+                #title = "%s{{%s}}" % (tmp_title, pw.strip())
+                #logger.log('Password found: {{%s}}' %(pw.strip()), logger.DEBUG)
+                title = "%s{{%s}}" % (tmp_title, p00_test3)
+                logger.log('Password found: {{%s}}' %(p00_test3), logger.DEBUG)
 
             params = {"nid": dl["href"].split("nid=")[1], "user": self.username, "pass": self.api_key, "rel": title}
             url = 'http://cytec.us/nzbto/index.php?' + urllib.urlencode(params)


### PR DESCRIPTION
fix for pw.strip() sometimes it will result in errors. some ascii chars are not removed.
happened on cubox with openelec
Problem ist hier 
x264-TVP%7B%7B%C2%A0usenet-4all.info_aWJLpo37v4tVp24%7D%7D
%7B%7B%C2%A0 ergibt {{Â 

Dadurch steht das Passwort in Sab so:
{{ usenet-4all.info_aWJLpo37v4tVp24}}
