### PR TITLE
Add german amazon, itunesHD sources

### DIFF
--- a/sickrage/recompiled/tags.py
+++ b/sickrage/recompiled/tags.py
@@ -11,8 +11,9 @@ dvd = re.compile(r'(?P<hd>hd)?dvd(?P<rip>rip|mux)?', re.I)
 web = re.compile(r'(web(?P<type>rip|mux|hd|.?dl|\b))', re.I)
 bluray = re.compile(r'(blue?-?ray|b[rd](?:rip|mux))', re.I)
 sat = re.compile(r'(dsr|satrip)', re.I)
-itunes = re.compile(r'(itunes)', re.I)
-netflix = re.compile(r'netflix(hd|uhd)', re.I)
+itunes = re.compile(r'itunes(hd|)', re.I)
+netflix = re.compile(r'netflix(hd|uhd|)', re.I)
+amazon = re.compile(r'amazon(hd|uhd|)', re.I)
 
 # Codecs
 avc = re.compile(r'([xh].?26[45])', re.I)

--- a/sickrage/tagger/episode.py
+++ b/sickrage/tagger/episode.py
@@ -29,6 +29,7 @@ class EpisodeTags(object):
             u'mpeg': tags.mpeg,
             u'xvid': tags.xvid,
             u'netflix': tags.netflix,
+            u'amazon': tags.amazon,
         }
 
     def _get_match_obj(self, attr, regex=None, flags=0):
@@ -122,6 +123,10 @@ class EpisodeTags(object):
             return 'dlmux'
         if self.netflix: 
             return self.netflix
+        if self.amazon: 
+            return self.amazon
+        if self.itunes:
+            return self.itunes
         else:
             attr = 'web'
             match = self._get_match_obj(attr)
@@ -269,5 +274,15 @@ class EpisodeTags(object):
         :return: an empty string if not found
         """
         attr = 'netflix'
+        match = self._get_match_obj(attr)
+        return '' if not match else match.group()
+
+    @property
+    def amazon(self):
+        """
+        Amazon tage found in name
+        :return: an empty string if not found
+        """
+        attr = 'amazon'
         match = self._get_match_obj(attr)
         return '' if not match else match.group()


### PR DESCRIPTION
Fixes #10 
The official Repo added NetflixHD like this so i added AmazonHD and iTunesHD the same way.

Proposed changes in this pull request:
- Added AmazonHD Tag
- Added iTunesHD Tag

Amazon, Netflix and iTunes Series are recognized as WEB-DL

- [ ] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
